### PR TITLE
Add directives to hide code and inject stylesheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,31 @@ show the number 42. Now you've learned all of the concepts in freeform! It's
 JavaScript, and you can use the `display()` method to show a value. See the rest
 of this readme for some examples.
 
+## Directives
+
+There are three directives that you can add to your code with `//-`. 
+
+    ```freeform
+
+    // If you do not want the code to appear below the result `iframe`, set the following
+    
+    //- showCode:false
+
+    // If you need to add some style css to the head of the `iframe`, set the following
+    // (you can have as many of these directives as you would like)
+    
+    //- styleText:body { font-family: "Helvetica", Sans-Serif; } 
+
+    // If you need to load a stylesheet in the head of the `iframe`, set the following
+    //- styleLinkUrl:https://some/url/stylesheet.css
+
+    // Note that Obsidian Content-Security-Policy does not allow for
+    // <link rel="stylesheet" href="..."> directives. Instead, the data from the url will be downloaded
+    // and the text of the stylesheet injected into the `iframe` top `<style>` element. 
+
+    // Your code ...
+    ```
+
 ## Demo
 
 https://github.com/tmcw/obsidian-freeform/assets/32314/56b4e23a-2837-4a06-84c7-ee35b09c2634

--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ module.exports = class IframeBlockPlugin extends Plugin {
 
         const re = /^\/\/- (.+?):(.+)$/gm;  
         for ( const match of src.matchAll(re)) {
-          console.log(`Found directive ${match[1]} with argument ${match[2]}`);
+          // console.log(`Found directive ${match[1]} with argument ${match[2]}`);
           if ( match[1] == 'showCode' && match[2] == 'false' ) { showCode = false }
           if ( match[1] == 'styleText') {
             styleText += "\n" + match[2] + "\n";
@@ -27,7 +27,7 @@ module.exports = class IframeBlockPlugin extends Plugin {
           if ( match[1] == 'styleLinkUrl') {
             // We need to get the css from the URL
             const r = new Request(match[2]);
-            console.log(`url is ${r.url}`);
+            // console.log(`url is ${r.url}`);
             const response = await fetch(r);
             if (!response.ok) {
               throw new Error('Network response was not ok ' + response.statusText)
@@ -38,8 +38,8 @@ module.exports = class IframeBlockPlugin extends Plugin {
             styleText += "\n" + responseData + "\n";
           }
         }
-        console.log(`showCode is ${showCode}`)
-        console.log(`styleText is ${styleText}`)
+        // console.log(`showCode is ${showCode}`)
+        // console.log(`styleText is ${styleText}`)
 
         try {
           // Give this iframe an identifier so that when it sends messages
@@ -99,7 +99,7 @@ console.log(e);
           window.addEventListener("message", (evt) => {
             if (evt.data.type === "height" && evt.data.id === iframeId) {
               iframe.height = evt.data.height + 40 + "px";
-              console.log(`Ressize - height is now ${iframe.height}`)
+              // console.log(`Resize - height is now ${iframe.height}`)
             }
           });
 


### PR DESCRIPTION
I'm trying to use https://github.com/DHTMLX/gantt to show a Gantt chart in an Obsidian note. In order to use this, I need to inject CSS into the `iframe` top `<style>` element. Therefore, I've added code to `main.js` to search the code in the freeform block  for directives that start with `//-`. I've also made showing the code below the result iframe optional with a 
`//- showCode:false` directive.  I hope this is useful.